### PR TITLE
bugfix: release() method on correct member (pool -> connectionPool)

### DIFF
--- a/lib/pooled-connection.js
+++ b/lib/pooled-connection.js
@@ -17,7 +17,7 @@ function PooledConnection(connectionPool, config) {
 PooledConnection.prototype = Object.create(Connection.prototype);
 
 PooledConnection.prototype.release = function () {
-    this.pool.release(this);
+    this.connectionPool.release(this);
 };
 
 module.exports = PooledConnection;


### PR DESCRIPTION
Release was called on a non-existing object member. Please review & merge.
