### PR TITLE
modified poolConfig.min to accept 0 as a value

### DIFF
--- a/lib/connection-pool.js
+++ b/lib/connection-pool.js
@@ -19,7 +19,7 @@ function ConnectionPool(poolConfig, connectionConfig) {
 
     this.max = poolConfig.max || 50;
 
-    this.min = poolConfig.min || 10;
+    this.min = (poolConfig.min>=0) ? poolConfig.min : 10;
 
     this.idleTimeout = !poolConfig.idleTimeout && poolConfig.idleTimeout !== false
         ? 300000 //5 min


### PR DESCRIPTION
Allows for the ability to set a zero for minimum connections. Useful for those looking to reduce chattiness between peak load times