### PR TITLE
Ensure ConnectionPool min is no greater than max

### DIFF
--- a/lib/connection-pool.js
+++ b/lib/connection-pool.js
@@ -19,7 +19,7 @@ function ConnectionPool(poolConfig, connectionConfig) {
 
     this.max = poolConfig.max || 50;
 
-    this.min = poolConfig.min >= 0 ? poolConfig.min : 10;
+    this.min = Math.min(this.max, poolConfig.min >= 0 ? poolConfig.min : 10);
 
     this.idleTimeout = !poolConfig.idleTimeout && poolConfig.idleTimeout !== false
         ? 300000 //5 min

--- a/test/connection-pool.test.js
+++ b/test/connection-pool.test.js
@@ -134,7 +134,7 @@ describe('ConnectionPool', function () {
                     assert.strictEqual(rowCount, 1);
                     connection.release();
                     setTimeout(function () {
-                        assert.equal(pool.connections.length, 0);
+                        assert.equal(pool.connections.length, 1);
                         pool.drain(done);
                     }, 200);
                 });
@@ -166,7 +166,7 @@ describe('ConnectionPool', function () {
                     assert.strictEqual(rowCount, 1);
                     connection.release();
                     setTimeout(function () {
-                        assert.equal(pool.connections.length, 0);
+                        assert.equal(pool.connections.length, 1);
                         pool.drain(done);
                     }, 200);
                 });

--- a/test/connection-pool.test.js
+++ b/test/connection-pool.test.js
@@ -116,6 +116,70 @@ describe('ConnectionPool', function () {
         }
     });
 
+    it('min<=max, min specified > max specified', function (done) {
+        this.timeout(10000);
+
+        var poolConfig = { min: 5, max: 1, idleTimeout: 10};
+        var pool = new ConnectionPool(poolConfig, connectionConfig);
+
+        setTimeout(function() {
+            assert.equal(pool.connections.length, 1);
+        }, 4);
+
+        setTimeout(function() {
+            pool.acquire(function(err, connection) {
+                assert(!err);
+
+                var request = new Request('select 42', function (err, rowCount) {
+                    assert.strictEqual(rowCount, 1);
+                    connection.release();
+                    setTimeout(function () {
+                        assert.equal(pool.connections.length, 0);
+                        pool.drain(done);
+                    }, 200);
+                });
+
+                request.on('row', function (columns) {
+                    assert.strictEqual(columns[0].value, 42);
+                });
+
+                connection.execSql(request);
+            });
+        }, 2000);
+    });
+
+    it('min<=max, no min specified', function (done) {
+        this.timeout(10000);
+
+        var poolConfig = {max: 1, idleTimeout: 10};
+        var pool = new ConnectionPool(poolConfig, connectionConfig);
+
+        setTimeout(function() {
+            assert.equal(pool.connections.length, 1);
+        }, 4);
+
+        setTimeout(function() {
+            pool.acquire(function(err, connection) {
+                assert(!err);
+
+                var request = new Request('select 42', function (err, rowCount) {
+                    assert.strictEqual(rowCount, 1);
+                    connection.release();
+                    setTimeout(function () {
+                        assert.equal(pool.connections.length, 0);
+                        pool.drain(done);
+                    }, 200);
+                });
+
+                request.on('row', function (columns) {
+                    assert.strictEqual(columns[0].value, 42);
+                });
+
+                connection.execSql(request);
+            });
+        }, 2000);
+    });
+
     it('pool error event', function (done) {
         var poolConfig = {min: 2, max: 5};
         var pool = new ConnectionPool(poolConfig, {});


### PR DESCRIPTION
As discussed in #16.  I left the package.json version untouched as possibly this could be considered a higher impact change.  It could be potentially breaking if somebody was incorrectly setting `max` to a low value, but still relying on `min` to be higher.

P.S.  I found all of the tests to be rather flaky (randomly failing), but particularly the 'acquire timeout' and 'release(), reset()' tests.