### PR TITLE
added 'new-connection' and 'new-connection-pooled' events to pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,16 +83,30 @@ pool.drain();
 ### connectionPool.acquire(callback)
 Acquire a Tedious Connection object from the pool.
 
- * `callback(err, connection)` {Function} Callback function
-  * `err` {Object} An Error object is an error occurred trying to acquire a connection, otherwise null.
+* `callback(err, connection)` {Function} Callback function
+  * `err` {Object} The Error that occurred while trying to acquire a connection, otherwise null.
   * `connection` {Object} A [Connection](http://pekim.github.com/tedious/api-connection.html)
 
 ### connectionPool.drain(callback)
 Close all pooled connections and stop making new ones. The pool should be discarded after it has been drained.
- * `callback()` {Function} Callback function
 
-### connectionPool.error {event}
+* `callback()` {Function} Callback function
+
+### connectionPool 'error' {event}
 The 'error' event is emitted when a connection fails to connect to the SQL Server.
+
+* `err` {Object} The Error that occurred while trying to connect to the SQL Server.
+
+### connectionPool 'new-connection' {event}
+The 'new-connection' event is emitted when a new connection was just created. No other event-handlers are registered yet and it is not yet put into the connection pool at this point.
+
+* `new_con` {Object} The newly created [Connection](http://pekim.github.com/tedious/api-connection.html)
+
+### connectionPool 'new-connection-pooled' {event}
+The 'new-connection-pooled' event is emitted after the 'new-connection' event. At this point the internal event-handlers are already registered on the connection and it is already put into the connection pool.
+
+* `new_con` {Object} The newly pooled [Connection](http://pekim.github.com/tedious/api-connection.html)
+
 
 ## Class: Connection
 The following method is added to the Tedious [Connection](http://pekim.github.com/tedious/api-connection.html) object.

--- a/lib/connection-pool.js
+++ b/lib/connection-pool.js
@@ -64,6 +64,9 @@ function createConnection(pooled) {
     this.log('creating connection: ' + cid);
     var connection = new Connection(this.connectionConfig);
     connection.pool = this;
+    
+    self.emit('new-connection', connection);
+    
     if (pooled) {
         pooled.id = cid++;
         pooled.con = connection;
@@ -77,7 +80,7 @@ function createConnection(pooled) {
 
         this.connections.push(pooled);
     }
-
+    
     var handleError = function(err) {
         self.log('connection closing because of error');
 
@@ -128,6 +131,8 @@ function createConnection(pooled) {
     };
 
     connection.on('end', endHandler);
+    
+    self.emit('new-connection-pooled', connection);
 }
 
 function fill() {


### PR DESCRIPTION
This helps when you want to do something with a connection right after it has been created by the pool, or right after it has been internally registered & added to the list of connections in the pool.

For example I'm using this to register additional event-handlers that are logging debug messages from tedious in my own component.
(see https://github.com/drywolf/loopback-connector-sql-tds/blob/master/lib/SqlTdsConnector.ts#L69)

Thanks & Regards,
Wolfgang