### PR TITLE
Add pending state when connection is made idle, so it is not used again ready

### DIFF
--- a/lib/connection-pool.js
+++ b/lib/connection-pool.js
@@ -220,6 +220,7 @@ function setFree(pooled) {
     pooled.status = FREE;
     pooled.timeout = setTimeout(function() {
         self.log('closing idle connection: ' + pooled.id);
+        pooled.status = PENDING;
         pooled.con.close();
     }, this.idleTimeout);
 }


### PR DESCRIPTION
Set a connection that has timed out as idle into the PENDING state, so it is not used again.  Eventually a connection.end will occur and this connection will get removed and fill will be called to replace it.