### PR TITLE
allow user of ConnectionPool to override default tedious version

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Once the Tedious Connection object has been acquired, the tedious API can be use
 
 ```javascript
 var ConnectionPool = require('tedious-connection-pool');
+ConnectionPool.overrideTedious(require('tedious'));
 var Request = require('tedious').Request;
 
 var poolConfig = {
@@ -75,6 +76,9 @@ pool.drain();
 
 
 ## Class: ConnectionPool
+
+### ConnectionPool.overrideTedious(tedious)
+Create connections using specified tedious module rather than ConnectionPool's default version of tedious.
 
 ### new ConnectionPool(poolConfig, connectionConfig)
 

--- a/lib/connection-pool.js
+++ b/lib/connection-pool.js
@@ -1,5 +1,5 @@
 'use strict';
-var Connection = require('tedious').Connection;
+var Connection = require('tedious').Connection; // load default tedious version
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 
@@ -51,6 +51,11 @@ function ConnectionPool(poolConfig, connectionConfig) {
 }
 
 util.inherits(ConnectionPool, EventEmitter);
+
+ConnectionPool.overrideTedious = function(tedious) {
+    Connection = tedious.Connection; // allow user of ConnectionPool to override default tedious version
+    return ConnectionPool;
+};
 
 var cid = 1;
 


### PR DESCRIPTION
## Description
Add ConnectionPool.overrideTedious(tedious) to create connections using specified tedious module rather than ConnectionPool's default version of tedious.

## Related Issue
Issue #43 

## Motivation and Context
ConnectionPool requires a version of tedious; users of ConnectionPool might wish to update tedious on a different schedule than ConnectionPool updates tedious.

## How Has This Been Tested?
An internal project has been running with this change and an updated version of tedious for months. Testing is primarily on Linux but includes OS X and Windows as well.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
This is not a breaking change because using the new method is optional. If the new method is not called, ConnectionPool continues to use the same version of tedious it has been using.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
Any suggestions on what tests should be added? Perhaps there's some clever trick to pull in multiple versions of tedious under different names. Perhaps a test should wrap tedious.Connection and verify the wrapper got called?
- [ ] All new and existing tests passed.
